### PR TITLE
add github/comment.yml

### DIFF
--- a/github/comment.yml
+++ b/github/comment.yml
@@ -1,5 +1,5 @@
 parameters:
-  body: 'Hello World!'
+  comment: 'Hello World!'
   number: ''
   repo: ''
   token: ''
@@ -11,7 +11,7 @@ steps:
       exit 1
     else
       curl \
-      --data $(echo '{}' | jq --arg body "$BODY" '.body = $body') \
+      --data $(echo '{}' | jq --arg body "$COMMENT" '.body = $body') \
       --header "Authorization: token $TOKEN" \
       --header "Content-Type: application/json" \
       --request POST \
@@ -21,7 +21,7 @@ steps:
     fi
   displayName: 'Create a comment'
   env:
-    BODY: ${{ parameters.body }}
+    COMMENT: ${{ parameters.comment }}
     TOKEN: ${{ parameters.token }}
     NUMBER: ${{ parameters.number }}
     REPO: ${{ parameters.repo }}

--- a/github/comment.yml
+++ b/github/comment.yml
@@ -1,0 +1,26 @@
+parameters:
+  body: 'Hello World!'
+  number: ''
+  repo: ''
+  token: ''
+
+steps:
+- script: |
+    if [ -z "$TOKEN" ]; then
+      echo "Please input your GITHUB_TOKEN value."
+      exit 1
+    else
+      curl \
+      --data "{ \"body\": \"$BODY\" }" \
+      --header "Authorization: token $TOKEN" \
+      --header "Content-Type: application/json" \
+      --request POST \
+      --silent \
+      --show-error \
+      --url "https://api.github.com/repos/$REPO/issues/$NUMBER/comments"
+    fi
+  env:
+    BODY: ${{ parameters.body }}
+    TOKEN: ${{ parameters.token }}
+    NUMBER: ${{ parameters.number }}
+    REPO: ${{ parameters.repo }}

--- a/github/comment.yml
+++ b/github/comment.yml
@@ -11,7 +11,7 @@ steps:
       exit 1
     else
       curl \
-      --data $(echo '{}' | jq --arg body "$COMMENT" '.body = $body') \
+      --data "$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')" \
       --header "Authorization: token $TOKEN" \
       --header "Content-Type: application/json" \
       --request POST \

--- a/github/comment.yml
+++ b/github/comment.yml
@@ -11,7 +11,7 @@ steps:
       exit 1
     else
       curl \
-      --data "{ \"body\": \"$BODY\" }" \
+      --data $(echo '{}' | jq --arg body "$BODY" '.body = $body') \
       --header "Authorization: token $TOKEN" \
       --header "Content-Type: application/json" \
       --request POST \

--- a/github/comment.yml
+++ b/github/comment.yml
@@ -19,6 +19,7 @@ steps:
       --show-error \
       --url "https://api.github.com/repos/$REPO/issues/$NUMBER/comments"
     fi
+  displayName: 'Create a comment'
   env:
     BODY: ${{ parameters.body }}
     TOKEN: ${{ parameters.token }}


### PR DESCRIPTION
Because we will be using Azure Pipelines with GitHub ref. https://blog.github.com/2018-09-10-azure-pipelines-now-available-in-github-marketplace/ then we need re-usable templates stored in central location. This is for creating a comment on GitHub issues and pull requests